### PR TITLE
大佬，发现您的项目引入了org.apache.kafka:kafka-clients@0.10.0.1组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.hhli</groupId>
@@ -30,7 +29,7 @@
 		<feign.starter.version>1.4.5.RELEASE</feign.starter.version>
 		<cglib.version>3.2.8</cglib.version>
 
-		<kafka.version>0.10.0.1</kafka.version>
+		<kafka.version>2.7.2</kafka.version>
 		<testng.version>6.14.3</testng.version>
 		<mock.version>1.8.4</mock.version>
 		<cache.version>1.1.1</cache.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Kafka 安全漏洞
缺陷组件：org.apache.kafka:kafka-clients@0.10.0.1
漏洞编号：CVE-2021-38153
漏洞描述：Apache Kafka是美国阿帕奇（Apache）基金会的一套开源的分布式流媒体平台。该平台能够获取实时数据，用于构建对数据流的变化进行实时反应的应用程序。
Apache Kafka 存在安全漏洞，该漏洞源于 Apache Kafka 中的某些组件使用“Arrays.equals”来验证密码或密钥，容易受到定时攻击。本地用户可以滥用“Arrays.equals”来暴力破解访问凭据并提升系统权限。
影响范围：(∞, 2.7.2)
最小修复版本：2.7.2
缺陷组件引入路径：com.hhli:springboot-stduy@0.0.1-SNAPSHOT->org.apache.kafka:kafka-clients@0.10.0.1
```
另外我运行这个项目时，IDE的安全插件提示还有111个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p9867e